### PR TITLE
Don't set the AppID if we're a Windows Store app

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -3,6 +3,7 @@ const notifications = require('@nodert-win10/windows.ui.notifications')
 const EventEmitter = require('events')
 const util = require('util')
 const xmlEscape = require('xml-escape');
+const { getIsCentennial } = require('./utils')
 
 const { getAppId } = require('./utils')
 
@@ -51,7 +52,9 @@ class Notification extends EventEmitter {
     // Note Do not set this property to true in a toast sent to a Windows 8.x device.
     // Doing so will cause a compiler error or a dropped notification.
 
-    this.notifier = notifications.ToastNotificationManager.createToastNotifier(options.appId)
+    this.notifier = getIsCentennial() ?
+      notifications.ToastNotificationManager.createToastNotifier() :
+      notifications.ToastNotificationManager.createToastNotifier(options.appId);
   }
 
   /**


### PR DESCRIPTION
We want to call the overload of this method that doesn't use an explicit AppID if we're a Windows Store app when creating our toast manager