### PR TITLE
Updating NodeRT packages requires() and exposing ToastDismissalReason

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -1,4 +1,4 @@
-const notifications = require('@nodert-win10/windows.ui.notifications')
+const notifications = require('@nodert-win10-au/windows.ui.notifications')
 const { getIsCentennial, getAppId, log } = require('./utils')
 
 const history = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { getIsWindows, getWindowsVersion, setLogger } = require('./utils')
-const { noop, NoopClass } = require('./noops')
+const { noop, NoopClass, noopObject } = require('./noops')
 const win = getIsWindows() ? getWindowsVersion() : null
 
 let _exports
@@ -14,6 +14,7 @@ let _exports
 // so we just export no-ops with console warnings.
 if (process.platform !== 'win32' || !(win === '10.0' || win === '8.1' || win === '8')) {
   _exports = {
+    ToastDismissalReason: noopObject,
     ToastNotification: NoopClass,
     TileNotification: NoopClass,
     SecondaryTile: NoopClass,
@@ -28,6 +29,7 @@ if (process.platform !== 'win32' || !(win === '10.0' || win === '8.1' || win ===
   }
 } else {
   _exports = {
+    ToastDismissalReason: require('@nodert-win10-au/windows.ui.notifications').ToastDismissalReason,
     ToastNotification: require('./toast-notification'),
     TileNotification: require('./tile-notification'),
     SecondaryTile: require('./secondary-tile'),

--- a/src/noops.js
+++ b/src/noops.js
@@ -22,4 +22,11 @@ class NoopClass extends EventEmitter {
   static getXML () { return noop() }
 }
 
-module.exports = { noop, NoopClass }
+const noopObject = new Proxy({}, {
+  get: (target, name) => {
+    noop()
+    return undefined;
+  }
+})
+
+module.exports = { noop, NoopClass, noopObject }

--- a/src/noops.js
+++ b/src/noops.js
@@ -24,8 +24,7 @@ class NoopClass extends EventEmitter {
 
 const noopObject = new Proxy({}, {
   get: (target, name) => {
-    noop()
-    return undefined;
+    return noop()
   }
 })
 

--- a/src/noops.js
+++ b/src/noops.js
@@ -23,7 +23,7 @@ class NoopClass extends EventEmitter {
 }
 
 const noopObject = new Proxy({}, {
-  get: (target, name) => {
+  get: () => {
     return noop()
   }
 })

--- a/src/secondary-tile.js
+++ b/src/secondary-tile.js
@@ -30,8 +30,8 @@ class SecondaryTile {
    * @memberOf SecondaryTile
    */
   constructor (options = {}) {
-    StartScreen = StartScreen || require('@nodert-win10/windows.ui.startscreen')
-    Foundation = Foundation || require('@nodert-win10/windows.foundation')
+    StartScreen = StartScreen || require('@nodert-win10-au/windows.ui.startscreen')
+    Foundation = Foundation || require('@nodert-win10-au/windows.foundation')
 
     const tileId = this._validateTileId(options._validateTileId)
     const displayName = options.displayName || ''

--- a/src/tile-notification.js
+++ b/src/tile-notification.js
@@ -1,5 +1,5 @@
-const xml = require('@nodert-win10/windows.data.xml.dom')
-const notifications = require('@nodert-win10/windows.ui.notifications')
+const xml = require('@nodert-win10-au/windows.data.xml.dom')
+const notifications = require('@nodert-win10-au/windows.ui.notifications')
 const util = require('util')
 const xmlEscape = require('xml-escape')
 

--- a/src/tile-updater.js
+++ b/src/tile-updater.js
@@ -1,4 +1,4 @@
-const notifications = require('@nodert-win10/windows.ui.notifications')
+const notifications = require('@nodert-win10-au/windows.ui.notifications')
 
 class TileUpdater {
   /**

--- a/src/toast-notification.js
+++ b/src/toast-notification.js
@@ -1,5 +1,5 @@
-const xml = require('@nodert-win10/windows.data.xml.dom')
-const notifications = require('@nodert-win10/windows.ui.notifications')
+const xml = require('@nodert-win10-au/windows.data.xml.dom')
+const notifications = require('@nodert-win10-au/windows.ui.notifications')
 const EventEmitter = require('events')
 const util = require('util')
 const xmlEscape = require('xml-escape')

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,7 @@ const utils = {
   getAppId () {
     if (process.windowsStore) {
       try {
-        const appModel = require('@nodert-win10/windows.applicationmodel')
+        const appModel = require('@nodert-win10-au/windows.applicationmodel')
 
         // This is a horrible and sad hack that hopefully won't be always neccessary
         const familyName = appModel.Package.current.id.familyName


### PR DESCRIPTION
1. Replacing `@nodert-win10` with `@nodert-win10-au` to reflect `package.json` changes

2. For `dismissed` notifications event, NodeRT has the `ToastDismissalReason`  enum for comparison. Currently we need to hardcode that reason. This PR exposes it.
```
notification.on('dismissed', (_, { reason }) => {
    switch (reason) {
        case ToastDismissalReason.userCanceled: 
            console.log('userCanceled')
            break
        case ToastDismissalReason.applicationHidden: 
            console.log('applicationHidden')
            break
        case ToastDismissalReason.timedOut: 
            console.log('timedOut')
            break
        default:
            console.log('reason not handled')       
    }
})
```