### PR TITLE
electron.getGlobal does not exist, just use the `global` var

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -59,13 +59,12 @@ const utils = {
     }
 
     try {
-      const electron = require('electron')
       const isRenderer = require('is-electron-renderer')
 
       if (isRenderer) {
-        return electron.remote.getGlobal('appUserModelId')
+        return require('electron').remote.getGlobal('appUserModelId')
       } else {
-        return electron.getGlobal('appUserModelId')
+        return global.appUserModelId
       }
     } catch (e) {
       return null


### PR DESCRIPTION
When running in the main process, the catch block is always hit (leading to a return of `null`) because `electron.getGlobal` is not a function. In the main process, just get the `appUserModelId` from the shared `global` var.