### PR TITLE
fix: bring the activation args across the node boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-windows-notifications",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Native Windows notifications for Electron using NodeRT",
   "main": "./src/index.js",
   "scripts": {

--- a/src/toast-notification.js
+++ b/src/toast-notification.js
@@ -50,7 +50,7 @@ class ToastNotification extends EventEmitter {
 
     this.toast = new notifications.ToastNotification(xmlDocument)
     // The event args object for the activated event is returned by the UWP API as a basic Object type, so we cast it to ToastActivatedEventArgs
-    this.toast.on('activated', (t, e) => this.emit('activated', t, notifications.ToastActivatedEventArgs.castFrom(e)))
+    this.toast.on('activated', (t, e) => this.emit('activated', t, notifications.ToastActivatedEventArgs.castFrom(e)?.arguments))
     this.toast.on('dismissed', (..._args) => this.emit('dismissed', ..._args))
 
     // Temporarily disabled due to a bug with Node 7


### PR DESCRIPTION
The activation argument is a UWP API object that doesn't make it across the node boundary.. However, the only interesting property within that object is are the actual arguments as a string.  So let's return that via the event args instead. 